### PR TITLE
Fix byte-compilation warnings

### DIFF
--- a/director.el
+++ b/director.el
@@ -28,6 +28,8 @@
 ;; Simulate user sessions.
 
 ;;; Code:
+(require 'map)
+(require 'seq)
 
 (defvar director--delay 1)
 (defvar director--steps nil)


### PR DESCRIPTION
The byte-compiler complains about unknown seq and map functions unless they are required prior to being used.