### PR TITLE
feat: support :eval step

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ A step can be one of:
   using `listify-key-sequence` and can contain special
   characters, e.g. `(:type "\M-xsetenv\r")`
 - `:call`: shortcut to invoke an interactive command, e.g. `(:call setenv)`
+- `:eval': Lisp form; it will be evaluated
 - `:log`: Lisp form; it will be evaluated and its result will be
   written to log; e.g. `(:log (buffer-file-name (current-buffer)))`
 - `:wait`: number; seconds to wait before next step; overrides

--- a/director.el
+++ b/director.el
@@ -80,6 +80,7 @@ A step can be one of:
   using `listify-key-sequence' and can contain special
   characters, e.g. `(:type \"\\M-xsetenv\\r\")'
 - `:call': shortcut to invoke an interactive command, e.g. `(:call setenv)'
+- `:eval': Lisp form; it will be evaluated
 - `:log': Lisp form; it will be evaluated and its result will be
   written to log; e.g. `(:log (buffer-file-name (current-buffer)))'
 - `:wait': number; seconds to wait before next step; overrides
@@ -197,6 +198,10 @@ If DELAY-OVERRIDE is non-nil, the next step is delayed by that value rather than
            ;; we'd never get to schedule the step.
            (director--schedule-next)
            (call-interactively command))
+
+          (`(:eval ,form)
+           (eval form)
+           (director--schedule-next))
 
           (`(:log ,form)
            (director--schedule-next)


### PR DESCRIPTION
## Summary

<!-- What feature, enhancement, or fix does the PR provide? If more than one,
please open separate PRs. -->

- Add `:eval` step to support lisp execution between other steps

## Description
- When using `emacs-director` for testing, it can be useful to run lisp code between steps in order to setup variables or run any other commands or setup code that cannot be run interactively with `:call` or typed with `:type`.
- Previously the only way to do this was through the less direct means of using `:assert` or `:log`, but these perform other unwanted actions in this use-case on top of simply evaluating the lisp form.
- See this [example usage](https://github.com/trevorpogue/topspace/blob/d376bca4c8cd8e787f54e46d73389cf0a7cfafbd/tests/tests.el#L21) of the `:eval` step for more context.